### PR TITLE
feat: lifecycle storage foundation [rn] (1/4)

### DIFF
--- a/src/analytics/utils/lifecycleStorage.test.ts
+++ b/src/analytics/utils/lifecycleStorage.test.ts
@@ -1,0 +1,73 @@
+import {
+  getLifecycleVersion,
+  getLifecycleBuild,
+  setLifecycleVersionBuild,
+  LIFECYCLE_VERSION_KEY,
+  LIFECYCLE_BUILD_KEY,
+} from './lifecycleStorage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+describe('lifecycleStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads the lifecycle version key from AsyncStorage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('1.4.0');
+
+    const version = await getLifecycleVersion();
+
+    expect(version).toBe('1.4.0');
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith(LIFECYCLE_VERSION_KEY);
+  });
+
+  it('reads the lifecycle build key from AsyncStorage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('42');
+
+    const build = await getLifecycleBuild();
+
+    expect(build).toBe('42');
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith(LIFECYCLE_BUILD_KEY);
+  });
+
+  it('returns null when version key is missing', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    expect(await getLifecycleVersion()).toBeNull();
+    expect(await getLifecycleBuild()).toBeNull();
+  });
+
+  it('returns null when AsyncStorage throws on read', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    expect(await getLifecycleVersion()).toBeNull();
+    expect(await getLifecycleBuild()).toBeNull();
+  });
+
+  it('writes both version and build to AsyncStorage', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+    await setLifecycleVersionBuild('1.4.0', '42');
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      LIFECYCLE_VERSION_KEY,
+      '1.4.0'
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      LIFECYCLE_BUILD_KEY,
+      '42'
+    );
+  });
+
+  it('does not throw if write fails', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('fail'));
+
+    await expect(setLifecycleVersionBuild('1.0', '1')).resolves.toBeUndefined();
+  });
+});

--- a/src/analytics/utils/lifecycleStorage.ts
+++ b/src/analytics/utils/lifecycleStorage.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const LIFECYCLE_VERSION_KEY = 'metarouter:lifecycle:version';
+export const LIFECYCLE_BUILD_KEY = 'metarouter:lifecycle:build';
+
+/**
+ * Storage for app lifecycle state (last-seen version + build). Lives in a
+ * dedicated module so neither IdentityManager.reset() nor the client's reset()
+ * can wipe install/update history. Errors are swallowed so missing or
+ * unavailable storage is treated as "no prior lifecycle state" — the caller
+ * decides whether that means install or update.
+ */
+
+export async function getLifecycleVersion(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(LIFECYCLE_VERSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function getLifecycleBuild(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(LIFECYCLE_BUILD_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function setLifecycleVersionBuild(
+  version: string,
+  build: string
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LIFECYCLE_VERSION_KEY, version);
+    await AsyncStorage.setItem(LIFECYCLE_BUILD_KEY, build);
+  } catch {
+    // best-effort; cold-launch state will be re-derived on next run
+  }
+}


### PR DESCRIPTION
## Summary

- Slice **1 of 4** in the RN lifecycle stack ([sc-36800](https://app.shortcut.com/metarouter/story/36800)).
- Adds a dedicated `metarouter:lifecycle:*` AsyncStorage namespace plus thin async helpers (`getLifecycleVersion`, `getLifecycleBuild`, `setLifecycleVersionBuild`).
- No behavior changes outside the new module — feature stays inert until slice 3 wires it into `MetaRouterAnalyticsClient`.

## Stack

1. **This PR** — storage foundation (~110 LOC)
2. Lifecycle event emitter + tests
3. AnalyticsClient wiring + `openURL` public API + opt-in default
4. README documentation

## Test plan

- [x] `npx jest src/analytics/utils/lifecycleStorage.test.ts` — 6 tests cover read, write, missing keys, and storage failures (best-effort swallow)
- [x] `npx tsc --noEmit` clean